### PR TITLE
Updates MA57 to use new build and fix tests for Julia 1.1

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -6,7 +6,7 @@ const prefix = Prefix(get([a for a in ARGS if a != "--verbose"], 1, joinpath(@__
 
 const hsl_ma57_version = "5.2.0"
 const hsl_ma57_sha256 = "aedc5a3e22a7b86779efccaa89a7c82b6949768dbab35fceb85a347e326cf584"
-const hsl_ma57_archive = joinpath(here, "downloads", "hsl_ma57-$hsl_ma57_version.tar.gz")
+const hsl_ma57_archive = joinpath(@__DIR__, "downloads", "hsl_ma57-$hsl_ma57_version.tar.gz")
 
 const hsl_ma97_version = "2.4.0"
 const hsl_ma97_sha256 = "b91552164311add95f7228d1397a747611f08ffdc86a100df58ddfcedfdc7ca7"
@@ -16,7 +16,7 @@ const so         = Sys.isapple() ? "dylib" : "so"
 const all_load   = Sys.isapple() ? "-all_load" : "--whole-archive"
 const noall_load = Sys.isapple() ? "-noall_load" : "--no-whole-archive"
 
-hsl_archives = [hsl_ma97_archive]
+hsl_archives = [hsl_ma57_archive, hsl_ma97_archive]
 
 if any(isfile.(hsl_archives))
   products = Product[
@@ -32,14 +32,6 @@ if any(isfile.(hsl_archives))
   # Asserting every product has a download_info
   for p in products
     @assert haskey(download_info, p.variable_name)
-  end
-
-  info("looking for $hsl_ma57_archive")
-  if isfile(hsl_ma57_archive)
-    info("hsl_ma57 found")
-    include("build_hsl_ma57.jl")
-  else
-    info("hsl_ma57 not found")
   end
 
   # Install unsatisfied or updated dependencies:
@@ -76,6 +68,12 @@ if any(isfile.(hsl_archives))
   # Dependencies are supposedly installed, so we turn to HSL
   builddir = joinpath(usrdir, "src")
   mkpath(builddir)
+  if isfile(hsl_ma57_archive)
+    @info "building ma57"
+    push!(products, FileProduct(prefix, "lib/libhsl_ma57.$so", :libhsl_ma57))
+    include("build_hsl_ma57.jl")
+  end
+
   if isfile(hsl_ma97_archive)
     @info "building ma97"
     push!(products, FileProduct(prefix, "lib/libhsl_ma97.$so", :libhsl_ma97))

--- a/deps/build_hsl_ma57.jl
+++ b/deps/build_hsl_ma57.jl
@@ -1,26 +1,15 @@
-# HSL_MA57 package-specific dependencies.
-
 # Users should place hsl_ma57-x.y.z.tar.gz in ~/.julia/v0.j/HSL/deps/downloads
-libhsl_ma57 = library_dependency("libhsl_ma57", depends=[libblas, liblapack, libmetis4])
 
-hsl_ma57_depsdir = BinDeps.depsdir(libhsl_ma57)
-hsl_ma57_srcdir = joinpath(hsl_ma57_depsdir, "src")
-hsl_ma57_src = joinpath(hsl_ma57_srcdir, "hsl_ma57-$hsl_ma57_version")
-hsl_ma57_prefix = joinpath(hsl_ma57_depsdir, "usr")
-hsl_ma57_libdir = joinpath(hsl_ma57_depsdir, "usr", "lib")
-
-provides(SimpleBuild,
-         (@build_steps begin
-            BinDeps.ChecksumValidator(hsl_ma57_sha256, hsl_ma57_archive)
-            CreateDirectory(hsl_ma57_srcdir)
-            FileUnpacker(hsl_ma57_archive, hsl_ma57_srcdir, "hsl_ma57-$hsl_ma57_version")
-            (@build_steps begin
-              ChangeDirectory(hsl_ma57_src)
-              `patch -p1 -i $hsl_ma57_depsdir/downloads/get_factors.patch`
-              `./configure F77=gfortran CFLAGS=-fPIC FFLAGS="-fPIC -fopenmp" FCFLAGS="-fPIC -fopenmp" --prefix=$hsl_ma57_prefix --with-blas=-lblas --with-metis="-L$metis_libpath -lmetis"`
-              `make install`
-              `gfortran -fPIC -shared -Wl,$all_load $hsl_ma57_libdir/libhsl_ma57.a -lblas -llapack -L$metis_libpath -lmetis -lgomp -Wl,$noall_load -o $hsl_ma57_libdir/libhsl_ma57.$so`
-            end)
-          end), libhsl_ma57, os=:Unix)
-
-hsl_modules[:libhsl_ma57] = :libhsl_ma57
+open(hsl_ma57_archive) do f
+  if bytes2hex(sha256(f)) != hsl_ma57_sha256
+    error("SHA256 of HSL MA57 doesn't match")
+  end
+end
+run(`tar -zxf $hsl_ma57_archive -C $builddir`)
+cd("$builddir/hsl_ma57-$hsl_ma57_version")
+patchfile = joinpath(@__DIR__, "downloads", "get_factors.patch")
+run(`patch -p1 -i $patchfile`)
+run(`./configure --prefix=$usrdir F77=gfortran CFLAGS=-fPIC FFLAGS="-fPIC -fopenmp" FCFLAGS="-fPIC -fopenmp" --with-blas="-L$libdir -lopenblas" --with-metis="-L$libdir -lcoinmetis"`)
+run(`make install`)
+run(`gfortran -fPIC -shared -Wl,$all_load $libdir/libhsl_ma57.a -L$libdir -lopenblas -lcoinmetis -lgomp -Wl,$noall_load -o $libdir/libhsl_ma57.$so`)
+cd(@__DIR__)

--- a/src/HSL.jl
+++ b/src/HSL.jl
@@ -10,7 +10,7 @@ else
 end
 
 function __init__()
-  if @isdefined libhsl_ma97
+  if (@isdefined libhsl_ma57) || (@isdefined libhsl_ma97)
     check_deps()
   end
 end
@@ -22,6 +22,9 @@ const data_map = Dict{Type, Type}(Float32 => Cfloat,
                                   ComplexF64 => Cdouble)
 
 # package-specific definitions
+if (@isdefined libhsl_ma57) || haskey(ENV, "DOCUMENTER_KEY")
+  include("hsl_ma57.jl")
+end
 if (@isdefined libhsl_ma97) || haskey(ENV, "DOCUMENTER_KEY")
   include("hsl_ma97.jl")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,7 +6,9 @@ using Test
 
 include("../deps/deps.jl")
 
-if @isdefined libhsl_ma97
-    include("test_ma97.jl")
+if @isdefined libhsl_ma57
+  include("test_ma57.jl")
 end
-isdefined(HSL, :libhsl_ma57) && include("test_ma57.jl")
+if @isdefined libhsl_ma97
+  include("test_ma97.jl")
+end

--- a/test/test_ma57.jl
+++ b/test/test_ma57.jl
@@ -16,7 +16,8 @@ function test_ma57(A, M, b, xexact)
   # extract factors
   (L, D, s, p) = ma57_get_factors(M)
   S = spdiagm(0 => s)
-  P = sparse(eltype(A)(1)*I, M.n, M.n)[p, :]
+  P = sparse(1.0I, M.n, M.n)[p, :]
+  L = convert(SparseMatrixCSC{Float64,Int}, L) # Convert to 64 bits because \ is not defined for 32 bits.
   @test norm(P * S * A * S * P' - L * D * L') ≤ ϵ * norm(A)
 
   # test partial solves


### PR DESCRIPTION
I've rebased `ma57` according to our discussion yesterday, and this pull request is against that branch to fix the build system.
There is also a fix on the tests because Julia `\` is not working with `SparseMatrixCSC{Float32,Int32}` (https://github.com/JuliaLang/julia/issues/30849).