### PR TITLE
use push_preview = true in deploydocs

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -11,8 +11,11 @@ makedocs(
   pages = ["Reference" => "index.md"]
 )
 
-deploydocs(deps = nothing, make = nothing,
+deploydocs(
+  deps = nothing,
+  make = nothing,
   repo = "github.com/JuliaSmoothOptimizers/HSL.jl.git",
   target = "build",
-  devbranch = "main"
+  devbranch = "main",
+  push_preview = true,
 )


### PR DESCRIPTION
With this change, a new workflow named "documenter/deploy" appears in the list of checks when the docs have finished building.
Clicking on "details" takes you to the docs resulting from the pull request.