### PR TITLE
allow compiler flags to be part of HSL_FC

### DIFF
--- a/.github/workflows/CI_M1.yml
+++ b/.github/workflows/CI_M1.yml
@@ -1,0 +1,31 @@
+name: CI_M1
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, synchronize, reopened]
+jobs:
+  test:
+    name: Julia ${{ matrix.version }} - macOS - ${{ matrix.arch }} - ${{ github.event_name }}
+    runs-on: self-hosted
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - '1'
+        arch:
+          - x64
+    steps:
+      - uses: actions/checkout@v3
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
+      - name: Version Info
+        shell: julia --color=yes {0}
+        run: |
+          using InteractiveUtils
+          versioninfo()
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-runtest@v1

--- a/deps/build_hsl_ma57.jl
+++ b/deps/build_hsl_ma57.jl
@@ -13,6 +13,6 @@ run(
 )
 run(`make install`)
 run(
-  `$(HSL_FC) -fPIC -shared -Wl,$all_load $libdir/libhsl_ma57.a -L$libblas_dir $libblas -L$libmetis_dir -lmetis -lgomp -Wl,$noall_load -o $libdir/libhsl_ma57.$dlext`,
+  `$(split(HSL_FC)) -fPIC -shared -Wl,$all_load $libdir/libhsl_ma57.a -L$libblas_dir $libblas -L$libmetis_dir -lmetis -lgomp -Wl,$noall_load -o $libdir/libhsl_ma57.$dlext`,
 )
 cd(@__DIR__)


### PR DESCRIPTION
this is useful on Apple Silicon when compiling for x86_64,
among others, where HSL_FC = "gfortran -arch x86_64".