### PR TITLE
Remove allocations from factorizations and solves

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ rhss = hcat(rhs, rhs)
 
 ## factorize and solve
 LDL = Ma57(K)
-ma57_factorize(LDL)
+ma57_factorize!(LDL)
 LDL.info.rank
 x = ma57_solve(LDL, rhs)  # or x = LBL \ rhs
 norm(K*x - rhs)

--- a/src/hsl_ma57.jl
+++ b/src/hsl_ma57.jl
@@ -7,8 +7,7 @@ export ma57_coord,
   ma57_min_norm,
   ma57_least_squares,
   ma57_get_factors,
-  ma57_alter_d,
-  ldiv!
+  ma57_alter_d
 
 export Ma57Exception
 
@@ -482,12 +481,6 @@ for (fname, typ) in ((:ma57c_, Float32), (:ma57cd_, Float64))
       return b
     end
   end
-end
-
-import LinearAlgebra.ldiv!
-function ldiv!(x::Vector, ma57::Ma57, b::Vector)
-  ma57_solve!(ma57, b, x)
-  x .= b
 end
 
 ## iterative refinement

--- a/src/hsl_ma57.jl
+++ b/src/hsl_ma57.jl
@@ -1,5 +1,6 @@
 export Ma57_Control, Ma57_Info, Ma57
 export ma57_coord,
+  ma57_factorize!,
   ma57_factorize,
   ma57_solve!,
   ma57_solve,

--- a/src/hsl_ma57.jl
+++ b/src/hsl_ma57.jl
@@ -342,6 +342,16 @@ end
 ## Return values:
 
 * `M::Ma57`: `Ma57` object
+
+## Example:
+```JULIA
+julia> using HSL
+julia> T = Float64;
+julia> rows = Int32[1, 2, 3, 5, 3, 4, 5]; cols = Int32[1, 1, 2, 2, 3, 3, 5];
+julia> vals = T[2, 3, 4, 6, 1, 5, 1];
+julia> A = sparse(rows, cols, vals);
+julia> M = Ma57(A)
+julia> ma57_factorize!(M)      ## factorize `Ma57` object in place
 """
 function ma57_factorize! end
 
@@ -456,13 +466,7 @@ julia> T = Float64;
 julia> rows = Int32[1, 2, 3, 5, 3, 4, 5]; cols = Int32[1, 1, 2, 2, 3, 3, 5];
 julia> vals = T[2, 3, 4, 6, 1, 5, 1];
 julia> A = sparse(rows, cols, vals);
-julia> M = Ma57(A)
-julia> ma57_factorize!(M)      ## factorize `Ma57` object in place
-julia> F = ma57_factorize(A)  ## factorize sparse matrix and return `Ma57` object
-julia> M.info.largest_front
-4
-julia> A.info.largest_front   ## same result
-4
+julia> M = ma57_factorize(A)  ## factorize sparse matrix and return `Ma57` object
 ```
 """
 function ma57_factorize(A::SparseMatrixCSC{T, Ti}; kwargs...) where {T <: Ma57Data, Ti <: Integer}

--- a/test/test_ma57.jl
+++ b/test/test_ma57.jl
@@ -48,8 +48,9 @@ for T in (Float32, Float64)
   # give lower triangle: swap rows and cols
   LBL = ma57_coord(n, cols, rows, vals, control, info)
   ma57_factorize!(LBL)
+  work = similar(b)
   x = copy(b)
-  ldiv!(LBL, x)
+  ma57_solve!(LBL, x, work)
   ϵ = sqrt(eps(T))
   @test norm(x - xexact) ≤ ϵ * norm(xexact)
 

--- a/test/test_ma57.jl
+++ b/test/test_ma57.jl
@@ -5,7 +5,7 @@ getindex_traverse_col(::AbstractUnitRange, lo::Integer, hi::Integer) = lo:hi
 
 function test_ma57(A, M, b, xexact)
   ϵ = sqrt(eps(eltype(A)))
-  ma57_factorize(M)
+  ma57_factorize!(M)
   x = ma57_solve(M, b)
   @test norm(x - xexact) ≤ ϵ * norm(xexact)
 
@@ -47,7 +47,7 @@ for T in (Float32, Float64)
   control.icntl[6] = 4  # choose a different ordering
   # give lower triangle: swap rows and cols
   LBL = ma57_coord(n, cols, rows, vals, control, info)
-  ma57_factorize(LBL)
+  ma57_factorize!(LBL)
   x = copy(b)
   ldiv!(LBL, x)
   ϵ = sqrt(eps(T))

--- a/test/test_ma57_patch.jl
+++ b/test/test_ma57_patch.jl
@@ -1,6 +1,6 @@
 function test_ma57_patch(A, M, b, xexact)
   ϵ = sqrt(eps(eltype(A)))
-  ma57_factorize(M)
+  ma57_factorize!(M)
 
   # extract factors
   (L, D, s, p) = ma57_get_factors(M)


### PR DESCRIPTION
- `ma57_factorize(ma57::Ma57)` is now  `ma57_factorize!(ma57::Ma57)`.
- `ma57_solve!` now requires a work vector.
- `ldiv!` has been removed, since its behaviour cannot be copied (in this case the 2-args `ldiv!` would have to allocate, and the 3-args `ldiv!` would erase the right-hand side, which is not the behaviour of the 3-args `div!` from LinearAlgebra).

This PR allows to remove the allocation of:
- 1 `Vector{Int32}` of size `ma57.n` at each `ma57_factorize!(ma57)` call,
- 1 `Vector{Int32}` of size `ma57.n` and 1 `Vector{Float}` `work` of size `ma57.n * size(b, 2)` at each `ma57_solve!(ma57, b, work)` call.