### PR TITLE
Fix tests with the MA57 patch

### DIFF
--- a/test/test_ma57_patch.jl
+++ b/test/test_ma57_patch.jl
@@ -24,7 +24,7 @@ function test_ma57_patch(A, M, b, xexact)
 
   # alter the D factor
   d1 = abs.(diag(D))
-  d2 = [diag(D, 1); 0]
+  d2 = [diag(D, 1); 0][:]
   ma57_alter_d(M, [Vector(d1)'; Vector(d2)'])
 end
 


### PR DESCRIPTION
With Julia 1.8, `d2 = [diag(D, 1); 0]` returns a `SparseMatrixCSC`.
It was a `SparseVector` wih previous versions of Julia.