### PR TITLE
[CI_M1] file -> files

### DIFF
--- a/.github/workflows/CI_M1.yml
+++ b/.github/workflows/CI_M1.yml
@@ -34,4 +34,4 @@ jobs:
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v3
         with:
-          file: lcov.info
+          files: lcov.info


### PR DESCRIPTION
`codecov/codecov-action@v2` and `codecov/codecov-action@v3` use `files` whereas `codecov/codecov-action@v1` uses `file`.