### PR TITLE
Test that we can use Apple Accelerate by default on Mac

### DIFF
--- a/src/HSL.jl
+++ b/src/HSL.jl
@@ -17,7 +17,14 @@ function __init__()
   if VERSION ≥ v"1.7"
     config = LinearAlgebra.BLAS.lbt_get_config()
     if !any(lib -> lib.interface == :lp64, config.loaded_libs)
-      LinearAlgebra.BLAS.lbt_forward(OpenBLAS32_jll.libopenblas_path)
+      if !Sys.isapple()
+        LinearAlgebra.BLAS.lbt_forward(OpenBLAS32_jll.libopenblas_path)
+      else
+        blas = "/System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/libBLAS.dylib"
+        lapack = "/System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/libLAPACK.dylib"
+        LinearAlgebra.BLAS.lbt_forward(blas, verbose = true, clear = false)
+        LinearAlgebra.BLAS.lbt_forward(lapack, verbose = true, clear = false)
+      end
     end
   end
   if (@isdefined libhsl_ma57) || (@isdefined libhsl_ma97) || (@isdefined libmc21)


### PR DESCRIPTION
It's documented nowhere but I found this in the tests of LBT:
https://github.com/JuliaLinearAlgebra/libblastrampoline/blob/main/test/runtests.jl#L150-L165

We have CI with a M1 so we can test it.