### PR TITLE
generic jenkinsfile for unit tests that run automatically

### DIFF
--- a/test/Jenkinsfile
+++ b/test/Jenkinsfile
@@ -1,4 +1,8 @@
 def prNumber = BRANCH_NAME.tokenize("PR-")[0]
+def runTestPath = "BenchmarkSetup/test/run_tests.sh"
+def pattern = "[a-zA-Z0-9]+?.jl"
+def repoName = (CHANGE_URL =~ pattern)[0]
+def token = repoName.tokenize(".")[0]
 pipeline {
   agent any
   options {
@@ -8,32 +12,18 @@ pipeline {
     GenericTrigger(
      genericVariables: [
         [
-            key: 'action', 
-            value: '$.action',
-            expressionType: 'JSONPath', //Optional, defaults to JSONPath
-            regexpFilter: '[^(created)]', //Optional, defaults to empty string
-            defaultValue: '' //Optional, defaults to empty string
-        ],
-        [
-            key: 'comment',
-            value: '$.comment.body',
-            expressionType: 'JSONPath', //Optional, defaults to JSONPath
-            regexpFilter: '', //Optional, defaults to empty string
-            defaultValue: '' //Optional, defaults to empty string
-        ],
-        [
             key: 'org',
             value: '$.organization.login',
             expressionType: 'JSONPath', //Optional, defaults to JSONPath
             regexpFilter: '', //Optional, defaults to empty string
-            defaultValue: 'JuliaSmoothOptimizers' //Optional, defaults to empty string
+            defaultValue: '' //Optional, defaults to empty string
         ],
         [
             key: 'pullrequest',
-            value: '$.issue.number',
+            value: '$.pull_request.number',
             expressionType: 'JSONPath', //Optional, defaults to JSONPath
-            regexpFilter: '[^0-9]', //Optional, defaults to empty string
-            defaultValue: '' //Optional, defaults to empty string
+            regexpFilter: '', //Optional, defaults to empty string
+            defaultValue: '$prNumber' //Optional, defaults to empty string
         ],
         [
             key: 'repo',
@@ -44,25 +34,41 @@ pipeline {
         ]
      ],
 
-     causeString: 'Triggered on comment',
+     causeString: 'Triggered on pullrequest update/creation',
 
-     token: "HSLTest",
+     token: "$token",
 
      printContributedVariables: true,
      printPostContent: true,
 
      silentResponse: false,
 
-     regexpFilterText: '$comment $pullrequest',
-     regexpFilterExpression: '@JSOBot runtests ' + prNumber
+     regexpFilterText: '$pullrequest',
+     regexpFilterExpression: prNumber
     )
   }
   stages {
-    stage('run tests') {
+    stage('clone Setup') {
+      when {
+        expression { env.repo && env.repo }
+      }
       steps {
-        sh "chmod +x test/run_tests.sh"
+        sh "git clone ${JENKINS_SETUP_URL} || true"
+      }
+    }
+    stage('run tests') {
+      when {
+        expression { env.repo && env.repo }
+      }
+      steps {
+        script {
+          if (fileExists('test/run_tests.sh')) {
+            runTestPath = 'test/run_tests.sh';
+          }
+        }
+        sh "chmod +x ${runTestPath}"
         sh "mkdir -p $HOME/tests/${org}/${repo}"
-        sh "qsub -N ${repo}_${pullrequest}_test -V -cwd -e $HOME/tests/${org}/${repo}/${pullrequest}_${BUILD_NUMBER}_error.log test/run_tests.sh"
+        sh "qsub -N ${repo}_${pullrequest}_test -V -cwd -e $HOME/tests/${org}/${repo}/${pullrequest}_${BUILD_NUMBER}_error.log ${runTestPath}"
       }
     }
   }
@@ -72,10 +78,6 @@ pipeline {
     }
     cleanup {
       sh 'printenv'
-      sh '''
-      git clean -fd
-      git reset --hard
-      '''
     }
   }
 }

--- a/test/Jenkinsfile
+++ b/test/Jenkinsfile
@@ -50,7 +50,7 @@ pipeline {
   stages {
     stage('clone Setup') {
       when {
-        expression { env.repo && env.repo }
+        expression { env.repo && env.org && env.pullrequest  }
       }
       steps {
         sh "git clone ${JENKINS_SETUP_URL} || true"
@@ -58,7 +58,7 @@ pipeline {
     }
     stage('run tests') {
       when {
-        expression { env.repo && env.repo }
+        expression { env.repo && env.org && env.pullrequest }
       }
       steps {
         script {


### PR DESCRIPTION
This new Jenkinsfile is now completely generic. The new features are: 

1. No longer needed to specify a token manually. It is automatically set to `"$(module_name)_Test"` (i.e, HSLTest).
2. It is no longer **required** to have the `test/run_tests.sh` and the `test/send_gist_url` in the `test` subfolder.
2.1 If you still want to provide your own `test/run_tests.sh` script, the build will use the version found in the repository.
3. Unit tests will be available for all repositories of the JSO organization.
4.  Unit tests will run **automatically** on any change to the Pull Request.

For this repo, since the `test/send_gist_url.jl` has been modified from the default version found in [this repo](https://github.com/ProofOfConceptForJuliSmoothOptimizers/BenchmarkSetup), we should keep both files as is. 
