### PR TITLE
Add coinhsl

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -124,7 +124,7 @@ function build_hsl(software::String)
                    --with-lapack="-L$libblas_dir $libblas"
                    --with-metis="-L$libmetis_dir -lmetis4"`)
   run(`make install`)
-  if software != "hsl_ma97"
+  if software != "hsl_ma97" && software != "coinhsl"
     run(`$(split(HSL_FC)) -fPIC -shared $all_load $libdir/lib$(software).a $noall_load
                                         -L$libblas_dir $libblas -L$libmetis_dir -lmetis4 -lgomp
                                         -o $libdir/lib$(software).$dlext`)

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -124,7 +124,7 @@ function build_hsl(software::String)
                    --with-lapack="-L$libblas_dir $libblas"
                    --with-metis="-L$libmetis_dir -lmetis4"`)
   run(`make install`)
-  if software != "hsl_ma97" && software != "coinhsl"
+  if software != "hsl_ma97"
     run(`$(split(HSL_FC)) -fPIC -shared $all_load $libdir/lib$(software).a $noall_load
                                         -L$libblas_dir $libblas -L$libmetis_dir -lmetis4 -lgomp
                                         -o $libdir/lib$(software).$dlext`)

--- a/deps/versions.jl
+++ b/deps/versions.jl
@@ -264,3 +264,10 @@ hsl_collection["hsl_zb01"] = []
 ## ZD: Derived types
 
 hsl_collection["hsl_zd11"] = []
+
+## HSL for IPOPT
+
+hsl_collection["coinhsl"] = [
+  HSLVersion("2021.05.05", "f4fa0eee24a181fbc88e8fe5a1c49443c34bb32b93b9f5b3a9c482324f87fa1d", ".tar.gz"),
+  HSLVersion("2021.05.05", "80a38ddca1bbedc8eb03a941d9a39478a3fd7b1bddbd2ae8220214a4ef59e4f9", ".zip"),
+]

--- a/src/HSL.jl
+++ b/src/HSL.jl
@@ -3,6 +3,7 @@ module HSL
 using LinearAlgebra
 using SparseArrays
 
+using SHA
 using METIS4_jll
 using OpenBLAS32_jll
 using libblastrampoline_jll
@@ -33,9 +34,17 @@ const data_map = Dict{Type, Type}(
   ComplexF64 => Cdouble,
 )
 
+function getsha(archivepath::String)
+  !isfile(archivepath) && error("$archivepath is not a file!")
+  open(archivepath) do f
+    return bytes2hex(sha256(f))
+  end
+end
+
 # package-specific definitions
 if @isdefined available_hsl_algorithms
   for package in keys(available_hsl_algorithms)
+    package == "coinhsl" && continue
     include("$(package).jl")
     if package == "hsl_ma57" && hsl_ma57_patched
       include("hsl_ma57_patch.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,6 +14,7 @@ if @isdefined available_hsl_algorithms
   end
 
   for package in keys(available_hsl_algorithms)
+    package == "coinhsl" && continue
     include("test_$(package).jl")
     if package == "hsl_ma57" && hsl_ma57_patched
       include("test_hsl_ma57_patch.jl")


### PR DESCRIPTION
@dpo
- Add a function `getsha` to easily compute the SHA of new releases.
- Add `hsl_collection["coinhsl"]` in `deps/versions.jl`.

With this PR, `coinhsl` is automatically compiled with METIS_jll, and OpenBLAS32_jll / LBT_jll.
We use the most efficient optimization level `-03` like the other packages.
The user just needs to provide `ENV["HSL_ARCHIVES_PATH"]` such that we know where the `.zip` and `tar.gz` are located on the computer.
```julia
set_optimizer_attribute(model, "hsllib", HSL.libcoinhsl)

set_optimizer_attribute(model, "linear_solver", "ma27")
set_optimizer_attribute(model, "linear_solver", "ma86")
...
```
cc @odow @tmigot for `Ipopt.jl` and `NLPModelsIpopt.jl`

If a user only has `MA97` for instance, it's still possible to use it in Ipopt:
```julia
set_optimizer_attribute(model, "hsllib", HSL.libhsl_ma97)
set_optimizer_attribute(model, "linear_solver", "ma97")
```