### PR TITLE
Use the new version of METIS4_jll

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,7 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 libblastrampoline_jll = "8e850b90-86db-534c-a0d3-1478176c7d93"
 
 [compat]
-METIS4_jll = "400.0.300"
+METIS4_jll = "=400.0.301"
 OpenBLAS32_jll = "0.3.9"
 julia = "^1.6.0"
 

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -111,11 +111,11 @@ function build_hsl(software::String)
                    FCFLAGS="-O3 -fPIC -fopenmp"
                    --with-blas="-L$libblas_dir $libblas"
                    --with-lapack="-L$libblas_dir $libblas"
-                   --with-metis="-L$libmetis_dir -lmetis"`)
+                   --with-metis="-L$libmetis_dir -lmetis4"`)
   run(`make install`)
   if software != "hsl_ma97"
     run(`$(split(HSL_FC)) -fPIC -shared -Wl,$all_load $libdir/lib$(software).a
-                                        -L$libblas_dir $libblas -L$libmetis_dir -lmetis -lgomp
+                                        -L$libblas_dir $libblas -L$libmetis_dir -lmetis4 -lgomp
                                         -Wl,$noall_load -o $libdir/lib$(software).$dlext`)
   end
   cd(@__DIR__)


### PR DESCRIPTION
METIS4_jll is now a shared library, we changed the `soname` such that it can coexist with `metis.$dlext` of `METIS_jll`.
https://github.com/JuliaPackaging/Yggdrasil/pull/5829