### PR TITLE
Add 2022-11-09 coinhsl versions

### DIFF
--- a/deps/versions.jl
+++ b/deps/versions.jl
@@ -268,4 +268,6 @@ hsl_collection["hsl_zd11"] = []
 hsl_collection["coinhsl"] = [
   HSLVersion("2021.05.05", "f4fa0eee24a181fbc88e8fe5a1c49443c34bb32b93b9f5b3a9c482324f87fa1d", ".tar.gz"),
   HSLVersion("2021.05.05", "80a38ddca1bbedc8eb03a941d9a39478a3fd7b1bddbd2ae8220214a4ef59e4f9", ".zip"),
+  HSLVersion("2022.11.09", "d6d9089bb9cf3eb0e4af195f1a2f10cd61da42eddf8da73a12b8c62902bceee3", ".tar.gz"),
+  HSLVersion("2022.11.09", "863acaf8e82001ff515fbf41e4056880e1f62185ffac02aa50907c9a82bcb1ca", ".zip"),
 ]


### PR DESCRIPTION
This PR adds version number and checksums for the 2022-11-09 `coinhsl` releases from HSL.

I have locally tested this version on a Linux (Redhat) system.
The build step works, `test HSL` runs without errors, and I was able to run sample problems with Ipopt as follows:
```julia
using HSL, JuMP, Ipopt

# I tested both configs below
opt = optimizer_with_attributes(Ipopt.Optimizer, "linear_solver" => "ma27", "hsllib" => HSL.libcoinhsl)
opt = optimizer_with_attributes(Ipopt.Optimizer, "linear_solver" => "ma57", "hsllib" => HSL.libcoinhsl)
model = Model(opt)
@variable(model, x >= 0)
@objective(model, Min, x*x)

optimize!(model)
```

I did not find reference checksums from HSL, so the checksum values are ones I computed by running on a Linux (WSL) machine
* `sha256sum coinhsl-2022.11.09.zip`
* `sha256sum coinhsl-2022.11.09.tar.gz`


