### PR TITLE
Bump version --> v0.3.6

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "HSL"
 uuid = "34c5aeac-e683-54a6-a0e9-6e0fdc586c50"
-version = "0.3.5"
+version = "0.3.6"
 
 [deps]
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"


### PR DESCRIPTION
Prep for a new release.
I use HSL solvers in Ipopt via HSL.jl. Having a tagged version would make it much easier to manage that.