### PR TITLE
Use the ccall macro in kb07, mc21 and mc77

### DIFF
--- a/src/kb07.jl
+++ b/src/kb07.jl
@@ -8,17 +8,14 @@ Sort an array of numbers `v` in-place into ascending order maintaining an index 
 """
 function kb07 end
 
-for (fname, elty) in (("kb07a_" , Float32),
-                      ("kb07ad_", Float64),
-                      ("kb07ai_", Cint))
+for (fname, elty) in ((:kb07a_ , :Float32),
+                      (:kb07ad_, :Float64),
+                      (:kb07ai_, :Cint))
   @eval begin
     function kb07(v::Vector{$elty})
       n = length(v)
       perm = zeros(Cint, n)
-      ccall(($fname, libkb07),
-             Cvoid,
-            (Ptr{$elty}, Ref{Cint}, Ptr{Cint}),
-             v         , n        , perm     )
+      @ccall libkb07.$fname(v::Ptr{$elty}, n::Ref{Cint}, perm::Ptr{Cint})::Cvoid
       return v, perm
     end
   end

--- a/src/mc21.jl
+++ b/src/mc21.jl
@@ -1,19 +1,8 @@
 export mc21
 
 # mc21a and mc21ad routines are identical.
-#
-# function mc21a(n, icn, licn, ip, lenr, iperm, numnz, iw)
-#   ccall(("mc21a_", libmc21),
-#          Cvoid,
-#         (Ref{Cint}, Ptr{Cint}, Ref{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ref{Cint}, Ptr{Cint}),
-#          n        , icn      , licn     , ip       , lenr     , iperm    , numnz    , iw       )
-# end
-
 function mc21ad(n, icn, licn, ip, lenr, iperm, numnz, iw)
-  ccall(("mc21ad_", libmc21),
-         Cvoid,
-        (Ref{Cint}, Ptr{Cint}, Ref{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ref{Cint}, Ptr{Cint}),
-         n        , icn      , licn     , ip       , lenr     , iperm    , numnz    , iw       )
+  @ccall libmc21.mc21ad_(n::Ref{Cint}, icn::Ptr{Cint}, licn::Ref{Cint}, ip::Ptr{Cint}, lenr::Ptr{Cint}, iperm::Ptr{Cint}, numnz::Ref{Cint}, iw::Ptr{Cint})::Cvoid
 end
 
 """

--- a/src/mc77.jl
+++ b/src/mc77.jl
@@ -1,22 +1,22 @@
 export mc77, mc77_control, mc77_info
 
-mutable struct mc77_control{T <: BLAS.BlasReal}
+mutable struct mc77_control{T}
   icntl::Vector{Int32}
   cntl::Vector{T}
 end
 
-function mc77_control{T}() where {T <: BLAS.BlasReal}
+function mc77_control{T}() where T
   icntl = zeros(Int32, 10)
   cntl = zeros(T, 10)
   return mc77_control{T}(icntl, cntl)
 end
 
-mutable struct mc77_info{T <: BLAS.BlasReal}
+mutable struct mc77_info{T}
   info::Vector{Int32}
   rinfo::Vector{T}
 end
 
-function mc77_info{T}() where {T <: BLAS.BlasReal}
+function mc77_info{T}() where T
   info = zeros(Int32, 10)
   rinfo = zeros(T, 10)
   return mc77_info{T}(info, rinfo)
@@ -24,67 +24,50 @@ end
 
 # mc77i sets default values for the components of the arrays that hold controlling parameters.
 # It should normally be called once prior to any other call.
-for (fname, subty) in (("mc77i_" , Float32),
-                       ("mc77id_", Float64))
+for (fname, subty) in ((:mc77i_ , :Float32),
+                       (:mc77id_, :Float64))
   @eval begin
-    function mc77i(control::mc77_control{$subty})
-      ccall(($fname, libmc77),
-      Cvoid,
-      (Ptr{Int32}   , Ptr{$subty} ),
-       control.icntl, control.cntl)
+    function mc77i(icntl, cntl::Vector{$subty})
+      @ccall libmc77.$fname(icntl::Ptr{Int32}, cntl::Ptr{$subty})::Cvoid
     end
   end
 end
 
 # mc77a computes the scaling matrices when A is sparse and stored by columns.
-for (fname, elty, subty) in (("mc77a_" , Float32   , Float32),
-                             ("mc77ad_", Float64   , Float64),
-                             ("mc77ac_", ComplexF32, Float32),
-                             ("mc77az_", ComplexF64, Float64))
+for (fname, elty, subty) in ((:mc77a_ , :Float32   , :Float32),
+                             (:mc77ad_, :Float64   , :Float64),
+                             (:mc77ac_, :ComplexF32, :Float32),
+                             (:mc77az_, :ComplexF64, :Float64))
   @eval begin
-    function mc77a(job::Int32, m::Int32, n::Int32, nnz::Int32, jcst::Vector{Int32},
-                   irn::Vector{Int32}, a::Vector{$elty}, iw::Vector{Int32}, liw::Int32,
-                   dw::Vector{$subty}, ldw::Int32, icntl::Vector{Int32}, cntl::Vector{$subty},
-                   info::Vector{Int32}, rinfo::Vector{$subty})
-      ccall(($fname, libmc77),
-      Cvoid,
-      (Ref{Int32}, Ref{Int32}, Ref{Int32}, Ref{Int32}, Ptr{Int32}, Ptr{Int32}, Ptr{Int32}, Ptr{Int32}, Ref{Int32}, Ptr{Int32}, Ref{Int32}, Ref{Int32}, Ref{$subty}, Ref{Int32}, Ref{$subty}),
-       job       , m         , n         , nnz       , jcst      , irn       , a         , iw        , liw       , dw        , ldw       , icntl     , cntl       , info      , rinfo)
+    function mc77a(job, m, n, nnz, jcst, irn, a::Vector{$elty}, iw, liw, dw, ldw, icntl, cntl, info, rinfo)
+      @ccall libmc77.$fname(job::Ref{Int32}, m::Ref{Int32}, n::Ref{Int32}, nnz::Ref{Int32}, jcst::Ptr{Int32}, irn::Ptr{Int32}, a::Ptr{$elty}, iw::Ptr{Int32},
+                            liw::Ref{Int32}, dw::Ptr{Int32}, ldw::Ref{Int32}, icntl::Ptr{Int32}, cntl::Ptr{$subty}, info::Ptr{Int32}, rinfo::Ptr{$subty})::Cvoid
     end
   end
 end
 
 # mc77b computes the scaling matrices when A is sparse and stored using the coordinate format.
-for (fname, elty, subty) in (("mc77b_" , Float32   , Float32),
-                             ("mc77bd_", Float64   , Float64),
-                             ("mc77bc_", ComplexF32, Float32),
-                             ("mc77bz_", ComplexF64, Float64))
+for (fname, elty, subty) in ((:mc77b_ , :Float32   , :Float32),
+                             (:mc77bd_, :Float64   , :Float64),
+                             (:mc77bc_, :ComplexF32, :Float32),
+                             (:mc77bz_, :ComplexF64, :Float64))
   @eval begin
-    function mc77b(job::Int32, m::Int32, n::Int32, nnz::Int32, irn::Vector{Int32}, jcn::Vector{Int32},
-                   a::Vector{$elty}, iw::Vector{Int32}, liw::Int32, dw::Vector{$subty},
-                   ldw::Int32, icntl::Vector{Int32}, cntl::Vector{$subty},
-                   info::Vector{Int32}, rinfo::Vector{$subty})
-      ccall(($fname, libmc77),
-      Cvoid,
-      (Ref{Int32}, Ref{Int32}, Ref{Int32}, Ref{Int32}, Ptr{Int32}, Ptr{Int32}, Ptr{Int32}, Ptr{Int32}, Ref{Int32}, Ptr{Int32}, Ref{Int32}, Ref{Int32}, Ref{$subty}, Ref{Int32}, Ref{$subty}),
-       job       , m         , n         , nnz       , irn       , jcn       , a         , iw        , liw       , dw        , ldw       , icntl     , cntl       , info      , rinfo)
+    function mc77b(job, m, n, nnz, irn, jcn, a::Vector{$elty}, iw, liw, dw, ldw, icntl, cntl, info, rinfo)
+      @ccall libmc77.$fname(job::Ref{Int32}, m::Ref{Int32}, n::Ref{Int32}, nnz::Ref{Int32}, irn::Ptr{Int32}, jcn::Ptr{Int32}, a::Ptr{$elty}, iw::Ptr{Int32},
+                            liw::Ref{Int32}, dw::Ptr{Int32}, ldw::Ref{Int32}, icntl::Ptr{Int32}, cntl::Ptr{$subty}, info::Ptr{Int32}, rinfo::Ptr{$subty})::Cvoid
     end
   end
 end
 
 # mc77c computes the scaling matrices when A is dense.
-for (fname, elty, subty) in (("mc77c_" , Float32   , Float32),
-                             ("mc77cd_", Float64   , Float64),
-                             ("mc77cc_", ComplexF32, Float32),
-                             ("mc77cz_", ComplexF64, Float64))
+for (fname, elty, subty) in ((:mc77c_ , :Float32   , :Float32),
+                             (:mc77cd_, :Float64   , :Float64),
+                             (:mc77cc_, :ComplexF32, :Float32),
+                             (:mc77cz_, :ComplexF64, :Float64))
   @eval begin
-    function mc77c(job::Int32, m::Int32, n::Int32, a::Matrix{$elty}, lda::Int32, iw::Vector{Int32},
-                   liw::Int32, dw::Vector{$subty}, ldw::Int32, icntl::Vector{Int32},
-                   cntl::Vector{$subty}, info::Vector{Int32}, rinfo::Vector{$subty})
-      ccall(($fname, libmc77),
-      Cvoid,
-      (Ref{Int32}, Ref{Int32}, Ref{Int32}, Ptr{Int32}, Ref{Int32}, Ptr{Int32}, Ref{Int32}, Ptr{Int32}, Ref{Int32}, Ref{Int32}, Ref{$subty}, Ref{Int32}, Ref{$subty}),
-       job       , m         , n         , a         , lda       , iw        , liw       , dw        , ldw       , icntl     , cntl      , info       , rinfo)
+    function mc77c(job, m, n, a::Matrix{$elty}, lda, iw, liw, dw, ldw, icntl, cntl, info, rinfo)
+      @ccall libmc77.$fname(job::Ref{Int32}, m::Ref{Int32}, n::Ref{Int32}, a::Ptr{$elty}, lda::Ref{Int32}, iw::Ptr{Int32}, liw::Ref{Int32},
+                            dw::Ptr{Int32}, ldw::Ref{Int32}, icntl::Ptr{Int32}, cntl::Ptr{$subty}, info::Ptr{Int32}, rinfo::Ptr{$subty})::Cvoid
     end
   end
 end
@@ -115,7 +98,7 @@ function mc77(A::SparseMatrixCSC{T}, job::Integer) where T <: BLAS.BlasFloat
   a = A.nzval
   R = real(T)
   control = mc77_control{R}()
-  mc77i(control)
+  mc77i(control.icntl, control.cntl)
   info = mc77_info{R}()
   if control.icntl[6] == 0
     liw = m+n
@@ -126,7 +109,7 @@ function mc77(A::SparseMatrixCSC{T}, job::Integer) where T <: BLAS.BlasFloat
   end
   iw = zeros(Int32, liw)
   dw = zeros(R, ldw)
-  mc77a(Int32(job), Int32(m), Int32(n), Int32(nz), jcst, irn, a, iw, Int32(liw), dw, Int32(ldw), control.icntl, control.cntl, info.info, info.rinfo)
+  mc77a(job, m, n, nz, jcst, irn, a, iw, liw, dw, ldw, control.icntl, control.cntl, info.info, info.rinfo)
   Dr = dw[1:m]
   Dc = dw[m+1:m+n]
   return Dr, Dc
@@ -139,7 +122,7 @@ function mc77(m::Integer, n::Integer, rows::Vector{Int32}, cols::Vector{Int32}, 
   a = nzval
   R = real(T)
   control = mc77_control{R}()
-  mc77i(control)
+  mc77i(control.icntl, control.cntl)
   info = mc77_info{R}()
   if control.icntl[6] == 0
     liw = m+n
@@ -150,7 +133,7 @@ function mc77(m::Integer, n::Integer, rows::Vector{Int32}, cols::Vector{Int32}, 
   end
   iw = zeros(Int32, liw)
   dw = zeros(R, ldw)
-  mc77b(Int32(job), Int32(m), Int32(n), Int32(nz), irn, jcn, a, iw, Int32(liw), dw, Int32(ldw), control.icntl, control.cntl, info.info, info.rinfo)
+  mc77b(job, m, n, nz, irn, jcn, a, iw, liw, dw, ldw, control.icntl, control.cntl, info.info, info.rinfo)
   Dr = dw[1:m]
   Dc = dw[m+1:m+n]
   return Dr, Dc
@@ -161,7 +144,7 @@ function mc77(A::Matrix{T}, job::Integer) where T <: BLAS.BlasFloat
   lda = max(1,stride(A,2))
   R = real(T)
   control = mc77_control{R}()
-  mc77i(control)
+  mc77i(control.icntl, control.cntl)
   info = mc77_info{R}()
   if control.icntl[6] == 0
     liw = m+n
@@ -172,7 +155,7 @@ function mc77(A::Matrix{T}, job::Integer) where T <: BLAS.BlasFloat
   end
   iw = zeros(Int32, liw)
   dw = zeros(R, ldw)
-  mc77c(Int32(job), Int32(m), Int32(n), A, Int32(lda), iw, Int32(liw), dw, Int32(ldw), control.icntl, control.cntl, info.info, info.rinfo)
+  mc77c(job, m, n, A, lda, iw, liw, dw, ldw, control.icntl, control.cntl, info.info, info.rinfo)
   Dr = dw[1:m]
   Dc = dw[m+1:m+n]
   return Dr, Dc


### PR DESCRIPTION
I also fixed an error in `mc77`, `a` is a `Ptr{$elty}` and not a `Ptr{Cint}`. I don't understand why It was working before...