### PR TITLE
Release 0.4.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "HSL"
 uuid = "34c5aeac-e683-54a6-a0e9-6e0fdc586c50"
-version = "0.3.6"
+version = "0.4.0"
 
 [deps]
 HSL_jll = "017b0a0e-03f4-516a-9b91-836bbd1904dd"


### PR DESCRIPTION
- Use JuliaHSL and the precompiled version HSL_jll.jl