### PR TITLE
Add an hidden argument in ccall for arrays of strings

### DIFF
--- a/gen/analyzer.jl
+++ b/gen/analyzer.jl
@@ -2,7 +2,7 @@
 using HSL_jll
 using JuliaFormatter
 
-release = "2023.9.27"
+release = "2023.10.5"
 libhsl = "/home/alexis/Bureau/git/hsl/libhsl/libHSL-$release/"
 
 # Symbols of the shared library libhsl
@@ -451,14 +451,13 @@ function main(name::String="all"; verbose::Bool=false)
             end
 
             # Hidden arguments
-            if "Ref{UInt8}" ∈ types || "Ptr{UInt8}" ∈ types
+            if "Ref{UInt8}" ∈ types || "Ptr{UInt8}" ∈ types || "Ptr{Ptr{UInt8}}" ∈ types
               verbose && @info "Hidden argument in $fname."
             end
             for k = 1:narguments
               (types[k] == "Ref{UInt8}") && write(file_wrapper, ", 1::Csize_t")
               (types[k] == "Ptr{UInt8}") && write(file_wrapper, ", $(strlen[arguments[k]])::Csize_t")
-              # FIX ME
-              # (types[k] == "Ptr{Ptr{UInt8}}") && ...
+              (types[k] == "Ptr{Ptr{UInt8}}") && write(file_wrapper, ", $(strlen[arguments[k]])::Csize_t")
             end
 
             if output_type == ""

--- a/src/Fortran/ma62.jl
+++ b/src/Fortran/ma62.jl
@@ -16,7 +16,7 @@ end
 
 function ma62pd(istrm, filnam, lenbuf, icntl, isave, info)
   @ccall libhsl.ma62pd_(istrm::Ptr{Cint}, filnam::Ptr{Ptr{UInt8}}, lenbuf::Ptr{Cint},
-                        icntl::Ptr{Cint}, isave::Ptr{Cint}, info::Ptr{Cint})::Cvoid
+                        icntl::Ptr{Cint}, isave::Ptr{Cint}, info::Ptr{Cint}, 128::Csize_t)::Cvoid
 end
 
 function ma62bd(nvar, ivar, ndf, last, lavar, avar, nrhsb, rhs, lx, x, lenbuf, lw, w, liw, iw,
@@ -142,7 +142,7 @@ end
 
 function ma62p(istrm, filnam, lenbuf, icntl, isave, info)
   @ccall libhsl.ma62p_(istrm::Ptr{Cint}, filnam::Ptr{Ptr{UInt8}}, lenbuf::Ptr{Cint},
-                       icntl::Ptr{Cint}, isave::Ptr{Cint}, info::Ptr{Cint})::Cvoid
+                       icntl::Ptr{Cint}, isave::Ptr{Cint}, info::Ptr{Cint}, 128::Csize_t)::Cvoid
 end
 
 function ma62b(nvar, ivar, ndf, last, lavar, avar, nrhsb, rhs, lx, x, lenbuf, lw, w, liw, iw, icntl,

--- a/src/Fortran/me62.jl
+++ b/src/Fortran/me62.jl
@@ -16,7 +16,7 @@ end
 
 function me62pd(istrm, filnam, lenbuf, icntl, isave, info)
   @ccall libhsl.me62pd_(istrm::Ptr{Cint}, filnam::Ptr{Ptr{UInt8}}, lenbuf::Ptr{Cint},
-                        icntl::Ptr{Cint}, isave::Ptr{Cint}, info::Ptr{Cint})::Cvoid
+                        icntl::Ptr{Cint}, isave::Ptr{Cint}, info::Ptr{Cint}, 128::Csize_t)::Cvoid
 end
 
 function me62bd(kind, nvar, ivar, ndf, last, lavar, avar, nrhsb, rhs, lx, x, lenbuf, lw, w, liw, iw,
@@ -146,7 +146,7 @@ end
 
 function me62p(istrm, filnam, lenbuf, icntl, isave, info)
   @ccall libhsl.me62p_(istrm::Ptr{Cint}, filnam::Ptr{Ptr{UInt8}}, lenbuf::Ptr{Cint},
-                       icntl::Ptr{Cint}, isave::Ptr{Cint}, info::Ptr{Cint})::Cvoid
+                       icntl::Ptr{Cint}, isave::Ptr{Cint}, info::Ptr{Cint}, 128::Csize_t)::Cvoid
 end
 
 function me62b(kind, nvar, ivar, ndf, last, lavar, avar, nrhsb, rhs, lx, x, lenbuf, lw, w, liw, iw,


### PR DESCRIPTION
https://community.intel.com/t5/Intel-Fortran-Compiler/Passing-array-of-strings-to-Fortran/m-p/767588