### PR TITLE
Fix the interface of MC77

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,8 @@ using Test, Random
 
 Random.seed!(666)  # Random tests are diabolical
 
+@info("HSL_INSTALLATION : $(HSL.HSL_INSTALLATION)")
+
 if LIBHSL_isfunctional()
   include("test_hsl_ma57.jl")
   include("test_hsl_ma97.jl")

--- a/test/test_hsl_ma57.jl
+++ b/test/test_hsl_ma57.jl
@@ -1,8 +1,3 @@
-import SparseArrays.getindex_traverse_col
-# this should be fixed in a future release
-# see
-getindex_traverse_col(::AbstractUnitRange, lo::Integer, hi::Integer) = lo:hi
-
 function test_ma57(A, M, b, xexact)
   ϵ = sqrt(eps(eltype(A)))
   ma57_factorize!(M)

--- a/test/test_mc77.jl
+++ b/test/test_mc77.jl
@@ -13,7 +13,7 @@
 
   for T ∈ (Float32, Float64, ComplexF32, ComplexF64)
     R = real(T)
-    for M ∈ (Matrix{T}(A), SparseMatrixCSC{T,Int32}(A))
+    for M ∈ (Matrix{T}(A), SparseMatrixCSC{T,Cint}(A))
       Dr, Dc = mc77(M, 0)
       @test round.(Dr, digits=3) ≈ R[10; 31.623; 0.729]
       @test round.(Dc, digits=3) ≈ R[10; 31.623; 0.159]


### PR DESCRIPTION
@frapac @michel2323
I fixed many bugs in the Julia interface of `MC77`.
It should work fine now.
To solve a scaled linear system, you just need:
```julia
Dr, Dc = mc77(A_cpu, 0)
inv_Dr = Diagonal(1.0 ./ Dr)
inv_Dc = Diagonal(1.0 ./ Dc)
As = inv_Dr * A * inv_Dc
bs = inv_Dr * b
xs = As \ bs
x = inv_Dc * xs
```

I checked the algorithm and we should be able to port this scaling on GPU if it performs well.