### PR TITLE
Fix omp_set_num_threads on Windows

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,6 +3,7 @@ uuid = "34c5aeac-e683-54a6-a0e9-6e0fdc586c50"
 version = "0.5.3"
 
 [deps]
+CompilerSupportLibraries_jll = "e66e0078-7015-5450-92f7-15fbd957f2ae"
 HSL_jll = "017b0a0e-03f4-516a-9b91-836bbd1904dd"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -11,6 +12,7 @@ Quadmath = "be4d8f0f-7fa4-5f49-b795-2f01399ab2dd"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
+CompilerSupportLibraries_jll = "1.0.5"
 HSL_jll = "4, 2024, 2025"
 Libdl = "1.9"
 LinearAlgebra = "1.9"

--- a/src/Fortran/openmp.jl
+++ b/src/Fortran/openmp.jl
@@ -1,5 +1,3 @@
 function omp_set_num_threads(num_threads)
-  @ccall libhsl.omp_set_num_threads_(num_threads::Ref{Cint})::Cvoid
-  @ccall libhsl_subset.omp_set_num_threads_(num_threads::Ref{Cint})::Cvoid
-  @ccall libhsl_subset_64.omp_set_num_threads_(num_threads::Ref{Cint})::Cvoid
+  @ccall libgomp.omp_set_num_threads_(num_threads::Ref{Cint})::Cvoid
 end

--- a/src/HSL.jl
+++ b/src/HSL.jl
@@ -6,6 +6,8 @@ using SparseArrays
 using Quadmath
 
 import OpenBLAS32_jll
+import CompilerSupportLibraries_jll
+libgomp::String = CompilerSupportLibraries_jll.libgomp
 import HSL_jll
 libhsl::String = HSL_jll.libhsl
 libhsl_subset::String = HSL_jll.libhsl_subset


### PR DESCRIPTION
Note that `CompilerSupportLibraries_jll` is already a dependency of `HSL_jll.jl`.
We need an explicit use of this JLL such that we can't call `omp_set_num_threads_` directly from `libgomp`.
On linux / mac, we can call the symbol from `libhsl*` libraries and then it is forwarded to `libgomp` but is not working on windows because the loader is another beast.
As always, things are different on Windows...

It should fix the use of `MA86` and `MA97` with `MadNLPHSL,jl` (on Windows).

cc @frapac @sshin23